### PR TITLE
Update S3 docs to use CAS instead of DynamoDB

### DIFF
--- a/docs/tutorials/abs.md
+++ b/docs/tutorials/abs.md
@@ -1,5 +1,6 @@
 ---
 title: Connect SlateDB to Azure Blob Storage
+sidebar_position: 1
 ---
 
 This tutorial shows you how to use SlateDB on Azure Blob Storage (ABS). You would need an ABS account to complete the tutorial.
@@ -53,7 +54,7 @@ cargo add slatedb object-store --features object-store/azure
 
 :::note
 
-If you see "`object_store::path::Path` and `object_store::path::Path` have similar names, but are actually distinct types", you might need to pin the `object_store` version to match `slatedb`'s `object_store` version.
+If you see "`object_store::path::Path` and `object_store::path::Path` have similar names, but are actually distinct types", you might need to pin the `object_store` version to match `slatedb`'s `object_store` version. SlateDB also exports `slatedb::object_store` for convenience, if you'd rather use that.
 
 :::
 

--- a/docs/tutorials/s3-legacy.md
+++ b/docs/tutorials/s3-legacy.md
@@ -1,9 +1,17 @@
 ---
-title: Connect SlateDB to S3
-sidebar_position: 2
+title: Connect SlateDB to S3 (Legacy)
+sidebar_position: 99
 ---
 
-This tutorial shows you how to connect SlateDB to S3. We'll use LocalStack to simulate S3.
+This tutorial shows you how to connect SlateDB to S3. We'll use LocalStack to simulate S3 and DynamoDB.
+
+:::warning
+
+This tutorial is deprecated. See the [Connect SlateDB to S3](/docs/tutorials/s3) tutorial.
+
+SlateDB no longer requires DynamoDB when working with S3. However, we've kept this tutorial for users that wish to use DynamoDB to manage [compare-and-swap](https://docs.rs/object_store/latest/object_store/aws/enum.S3ConditionalPut.html#variant.Dynamo) (CAS) anyway.
+
+:::
 
 ## Create a project
 
@@ -24,7 +32,7 @@ cargo add slatedb object-store tokio --features object-store/aws
 
 :::note
 
-If you see "`object_store::path::Path` and `object_store::path::Path` have similar names, but are actually distinct types", you might need to pin the `object_store` version to match `slatedb`'s `object_store` version. SlateDB also exports `slatedb::object_store` for convenience, if you'd rather use that.
+If you see "`object_store::path::Path` and `object_store::path::Path` have similar names, but are actually distinct types", you might need to pin the `object_store` version to match `slatedb`'s `object_store` version.
 
 :::
 
@@ -50,7 +58,7 @@ brew install awscli
 
 ## Initialize AWS
 
-SlateDB requires a bucket to work with S3.
+SlateDB requires a bucket and a DynamoDB table to work with S3.
 
 ### Create your S3 bucket:
 
@@ -59,12 +67,22 @@ SlateDB requires a bucket to work with S3.
 aws --endpoint-url=http://localhost:4566 s3api create-bucket --bucket slatedb --region us-east-1
 ```
 
+### Create your DynamoDB table:
+
+SlateDB has not yet implemented CAS for S3 ([#164](https://github.com/slatedb/slatedb/issues/164)). Instead, SlateDB uses DynamoDB to manage CAS (via the [`object_store`](https://docs.rs/object_store/latest/object_store/) crate).
+
+```bash
+# Create DynamoDB table
+aws --endpoint-url=http://localhost:4566 dynamodb create-table --table-name slatedb --key-schema AttributeName=path,KeyType=HASH AttributeName=etag,KeyType=RANGE --attribute-definitions AttributeName=path,AttributeType=S AttributeName=etag,AttributeType=S --billing-mode PAY_PER_REQUEST
+aws --endpoint-url=http://localhost:4566 dynamodb update-time-to-live --table-name slatedb --time-to-live-specification Enabled=true,AttributeName=ttl
+```
+
 ## Write some code
 
 Stick this into your `src/main.rs` file:
 
 ```rust
-use use object_store::aws::S3ConditionalPut;
+use object_store::aws::{DynamoCommit, S3ConditionalPut};
 use object_store::path::Path;
 use object_store::ObjectStore;
 use slatedb::config::DbOptions;
@@ -84,7 +102,7 @@ async fn main() {
             .with_secret_access_key("test")
             .with_bucket_name("slatedb")
             .with_region("us-east-1")
-            .with_conditional_put(S3ConditionalPut::ETagMatch)
+            .with_conditional_put(S3ConditionalPut::Dynamo(DynamoCommit::new("slatedb".to_string())))
             .build()
             .expect("failed to create object store")
     );


### PR DESCRIPTION
I opted to keep the old docs around as `s3-legacy.md` since some users might prefer to continue using DynamoDB for some reason.