### PR TITLE
[docs/tutorials] Fix compile error in s3.md

### DIFF
--- a/docs/tutorials/s3.md
+++ b/docs/tutorials/s3.md
@@ -68,7 +68,7 @@ use object_store::aws::S3ConditionalPut;
 use object_store::path::Path;
 use object_store::ObjectStore;
 use slatedb::config::DbOptions;
-use slatedb::db::Db;
+use slatedb::Db;
 use std::sync::Arc;
 
 #[tokio::main]


### PR DESCRIPTION
I was following the instructions, and noticed that the tutorial currently does not compile- likely because of module refactoring done in https://github.com/slatedb/slatedb/commit/ccc0534aa51c31c614cd95779b2c3f01a5bbc191.

after this change `cargo run` works.