### PR TITLE
fix: make tracing code compilable

### DIFF
--- a/docs/operations/logging.md
+++ b/docs/operations/logging.md
@@ -11,7 +11,7 @@ Here's a basic example showing how to consume tracing logs with `tracing_subscri
 ```rust
 use bytes::Bytes;
 use object_store::{ObjectStore, memory::InMemory, path::Path};
-use slatedb::db::Db;
+use slatedb::Db;
 use slatedb::config::DbOptions;
 use std::sync::Arc;
 


### PR DESCRIPTION
The code in section "Tracing in SlateDB" is not compilable.

The error is:

3  | use slatedb::db::Db;
   |              ^^ private module

This commit fixes the compilation error.